### PR TITLE
prover: normalize string assistant content on transcript replay

### DIFF
--- a/apps/lea-standalone/prover/lea/agent.py
+++ b/apps/lea-standalone/prover/lea/agent.py
@@ -806,7 +806,10 @@ def _run_events_inner(
                 # Surface it live + fold it into the transcript, so both the UI and the
                 # materialized sub-agent view carry the findings as the final message.
                 yield AssistantTextDelta(summary)
-                messages.append({"role": "assistant", "content": summary})
+                # Parts shape, like every other assistant turn: the transcript is
+                # persisted and replayed on the next activation, where
+                # _to_openai_messages iterates assistant content as a list of blocks.
+                messages.append({"role": "assistant", "content": [{"type": "text", "text": summary}]})
             final_text = summary or (
                 "Reached the cost budget without completing the task." if cost_capped
                 else "Reached the turn budget without completing the task."

--- a/apps/lea-standalone/prover/lea/providers.py
+++ b/apps/lea-standalone/prover/lea/providers.py
@@ -77,7 +77,7 @@ def _to_openai_messages(system: str, messages: list, *, include_reasoning: bool 
                 out.append({"role": "user", "content": msg["content"]})
             elif isinstance(msg["content"], list):
                 for item in msg["content"]:
-                    if item.get("type") == "tool_result":
+                    if isinstance(item, dict) and item.get("type") == "tool_result":
                         out.append({
                             "role": "tool",
                             "tool_call_id": item.get("tool_call_id") or item.get("tool_use_id"),
@@ -86,7 +86,17 @@ def _to_openai_messages(system: str, messages: list, *, include_reasoning: bool 
         elif msg["role"] == "assistant":
             oai = {"role": "assistant", "content": None}
             text_parts, tool_calls, reasoning_items = [], [], []
-            for item in msg["content"]:
+            content = msg["content"]
+            if isinstance(content, str):
+                # Transcripts persisted before assistant turns were normalized to
+                # parts (e.g. a max-turns summary) may still carry a bare string.
+                # Replay it as a single text part instead of iterating its characters.
+                content = [{"type": "text", "text": content}]
+            elif not isinstance(content, list):
+                content = []
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
                 if item.get("type") == "text":
                     text_parts.append(item["text"])
                 elif include_reasoning and item.get("type") == "reasoning":

--- a/apps/lea-standalone/prover/tests/providers/test_litellm_stream.py
+++ b/apps/lea-standalone/prover/tests/providers/test_litellm_stream.py
@@ -164,6 +164,37 @@ def test_gpt_5_6_responses_compatibility():
     check("legacy: provider-specific reasoning omitted", "reasoning_items" not in legacy_sent[2])
 
 
+def test_string_content_assistant_replay():
+    """A transcript persisted before assistant turns were normalized to parts may
+    carry a bare string as assistant content (e.g. a max-turns summary). Replaying
+    it must convert to a text message, not crash iterating the string's characters."""
+    legacy_transcript = [
+        {"role": "user", "content": "prove it"},
+        {"role": "assistant", "content": "Reached the turn budget without completing the task."},
+        {"role": "user", "content": "keep going"},
+    ]
+    sent = providers._to_openai_messages("SYS", legacy_transcript)
+    check("legacy transcript: no crash, 4 messages", len(sent) == 4)
+    check(
+        "legacy transcript: string assistant content becomes text",
+        sent[2] == {"role": "assistant",
+                    "content": "Reached the turn budget without completing the task."},
+    )
+    # Mixed: a parts-shaped turn and a non-dict stray in a user list must not crash either.
+    mixed = [
+        {"role": "assistant", "content": [
+            {"type": "text", "text": "hi"},
+            {"type": "tool_call", "name": "lean_check", "args": {"path": "/x.lean"}, "id": "call_9"},
+        ]},
+        {"role": "user", "content": ["stray", {"type": "tool_result", "tool_call_id": "call_9", "content": "OK"}]},
+    ]
+    sent = providers._to_openai_messages("SYS", mixed)
+    check("mixed: assistant text + tool call", sent[1]["content"] == "hi"
+          and sent[1]["tool_calls"][0]["id"] == "call_9")
+    check("mixed: stray non-dict user item skipped", sent[2]["role"] == "tool"
+          and sent[2]["tool_call_id"] == "call_9")
+
+
 def main():
     print("providers (LiteLLM stream) tests:")
     providers.litellm.completion = fake_completion
@@ -198,6 +229,7 @@ def main():
 
     test_blocking_mode()
     test_gpt_5_6_responses_compatibility()
+    test_string_content_assistant_replay()
 
     print()
     if _FAILURES:


### PR DESCRIPTION
A run that hit its turn/cost budget appended the final summary as a bare string, and the next activation's _to_openai_messages iterated it as a list of blocks, crashing with AttributeError: 'str' object has no attribute 'get'.

- agent.py: append the max-turns summary in parts shape like every other assistant turn
- providers.py: tolerate a string assistant content (replayed as one text part) and skip non-dict items, so transcripts already persisted in the store replay without a migration
- add a regression test for the legacy string-content shape