### PR TITLE
dev: make the adapter port configurable via LEA_ADAPTER_PORT

### DIFF
--- a/apps/lea-standalone/README.md
+++ b/apps/lea-standalone/README.md
@@ -76,6 +76,15 @@ The launcher:
 - starts Vite with `--host 0.0.0.0` on `http://localhost:5173`;
 - stops both child processes on `Ctrl+C`.
 
+If `:8001` is already taken on your machine, set `LEA_ADAPTER_PORT` to move the
+adapter; the launcher's preflight, the health probe, the Vite `/api` proxy and
+`npm run doctor` all follow it. Point the Overleaf companion at the new port with
+`LEA_API_BASE_URL` in the root `.env`.
+
+```sh
+LEA_ADAPTER_PORT=8011 npm run dev
+```
+
 To start only one process:
 
 ```sh

--- a/apps/lea-standalone/adapter/run_api.py
+++ b/apps/lea-standalone/adapter/run_api.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import os
 import sys
+
+# The adapter's listen port. Everything that talks to it in dev (scripts/dev.mjs,
+# the Vite /api proxy, scripts/doctor.mjs) reads the same variable, so overriding
+# it in one place moves the whole dev stack off :8001.
+PORT = int(os.environ.get("LEA_ADAPTER_PORT") or 8001)
 
 print("[startup] importing uvicorn", flush=True)
 import uvicorn
@@ -12,7 +18,7 @@ print("[startup] creating uvicorn config", flush=True)
 config = uvicorn.Config(
     app,
     host="127.0.0.1",
-    port=8001,
+    port=PORT,
     loop="asyncio",
     http="h11",
     log_level="debug",

--- a/apps/lea-standalone/package.json
+++ b/apps/lea-standalone/package.json
@@ -14,7 +14,7 @@
     "dev:web": "vite",
     "start:api": "cd adapter && ./.venv/bin/python run_api.py",
     "dev:api": "cd adapter && ./.venv/bin/python run_api.py",
-    "dev:api:venv": "cd adapter && ./.venv/bin/python -m uvicorn app.main:app --host 127.0.0.1 --port 8001 --loop asyncio --http h11 --log-level debug",
+    "dev:api:venv": "cd adapter && ./.venv/bin/python -m uvicorn app.main:app --host 127.0.0.1 --port ${LEA_ADAPTER_PORT:-8001} --loop asyncio --http h11 --log-level debug",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/lea-standalone/scripts/dev.mjs
+++ b/apps/lea-standalone/scripts/dev.mjs
@@ -9,6 +9,11 @@ import path from "node:path";
 // exports its own provider keys from config (D1·cfg). So dev runs just two
 // processes: the FastAPI adapter (:8001) and the Vite web dev server (:5173).
 const root = process.cwd();
+// Set LEA_ADAPTER_PORT to move the adapter off :8001 (e.g. when that port is
+// already taken by something else on the machine). adapter/run_api.py binds it,
+// vite.config.ts proxies /api to it, and scripts/doctor.mjs probes it — all from
+// this one variable, which children inherit through `env: process.env` below.
+const ADAPTER_PORT = Number(process.env.LEA_ADAPTER_PORT) || 8001;
 // In the monorepo, npm hoists workspace deps to the repo-root node_modules, so
 // this app may have no local node_modules. Resolve hoisted tools from either
 // place (local checkout first, then the monorepo root).
@@ -71,9 +76,10 @@ function portOpen(port, host = "127.0.0.1") {
   });
 }
 
-async function ensurePortAvailable(port, label) {
+async function ensurePortAvailable(port, label, envVar) {
   if (await portOpen(port)) {
-    fail(`${label} port ${port} is already in use. Stop the existing process and run npm run dev again.`);
+    const escape = envVar ? ` (or set ${envVar} to a free port)` : "";
+    fail(`${label} port ${port} is already in use. Stop the existing process${escape} and run npm run dev again.`);
   }
 }
 
@@ -124,12 +130,12 @@ if (nodeMajor !== 22 && nodeMajor !== 20) {
 // The adapter drives the prover in-process; it reads config/lea.local.toml and
 // exports provider keys to its own environment (D1·cfg), so there is nothing to
 // inject here.
-await ensurePortAvailable(8001, "UI adapter API");
+await ensurePortAvailable(ADAPTER_PORT, "UI adapter API", "LEA_ADAPTER_PORT");
 start("adapter", "./.venv/bin/python", ["run_api.py"], { cwd: path.join(root, "adapter") });
 
 try {
-  await waitFor("http://127.0.0.1:8001/api/health", "UI adapter API");
-  console.log("[dev] UI adapter API ready at http://127.0.0.1:8001");
+  await waitFor(`http://127.0.0.1:${ADAPTER_PORT}/api/health`, "UI adapter API");
+  console.log(`[dev] UI adapter API ready at http://127.0.0.1:${ADAPTER_PORT}`);
 } catch (error) {
   console.error(`[dev] ${error.message}`);
   shutdown(1);

--- a/apps/lea-standalone/scripts/doctor.mjs
+++ b/apps/lea-standalone/scripts/doctor.mjs
@@ -89,10 +89,12 @@ const apiImport = command(["./.venv/bin/python", "-c", "from app.main import app
 });
 checks.push(check("API imports", apiImport.status === 0, commandDetail(apiImport)));
 
+// Keep in step with LEA_ADAPTER_PORT (adapter/run_api.py, scripts/dev.mjs).
+const adapterPortNumber = Number(process.env.LEA_ADAPTER_PORT) || 8001;
 const frontendPort = await portOpen(5173);
-const adapterPort = await portOpen(8001);
+const adapterPort = await portOpen(adapterPortNumber);
 console.log(`[INFO] frontend port 5173 - ${frontendPort ? "already running" : "not running"}`);
-console.log(`[INFO] UI adapter API port 8001 - ${adapterPort ? "already running" : "not running"}`);
+console.log(`[INFO] UI adapter API port ${adapterPortNumber} - ${adapterPort ? "already running" : "not running"}`);
 
 if (!checks.every(Boolean)) {
   process.exitCode = 1;

--- a/apps/lea-standalone/vite.config.ts
+++ b/apps/lea-standalone/vite.config.ts
@@ -23,6 +23,10 @@ function pkgDir(pkg: string): string {
 const infoviewDist = path.join(pkgDir('@leanprover/infoview'), 'dist')
 const lean4monacoDist = path.join(pkgDir('lean4monaco'), 'dist')
 
+// Must match the adapter's bind port (adapter/run_api.py reads the same variable);
+// scripts/dev.mjs passes its environment through to this dev server.
+const adapterPort = Number(process.env.LEA_ADAPTER_PORT) || 8001
+
 function figmaAssetResolver() {
   return {
     name: 'figma-asset-resolver',
@@ -86,7 +90,7 @@ export default defineConfig({
     proxy: {
       // `ws: true` upgrades the live-editor LSP WebSocket (/api/sessions/:id/lsp,
       // v2.2 · D60) to the adapter; plain /api HTTP + SSE proxy unchanged.
-      '/api': { target: 'http://localhost:8001', ws: true },
+      '/api': { target: `http://localhost:${adapterPort}`, ws: true },
     },
     // The vendored prover holds huge Lean build trees (workspace + SafeVerify
     // .lake/ oleans, the ~189MB safe_verify binary). The frontend never imports

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -4,6 +4,11 @@
 #   - standalone UI: FastAPI adapter (:8001) + Vite frontend (:5173)  [npm run dev:ui]
 #   - Overleaf companion (:31245)                                     [npm run dev:overleaf]
 #
+# If :8001 is taken on your machine, set LEA_ADAPTER_PORT to move the adapter (the
+# Vite /api proxy follows it). The Overleaf companion needs to be pointed at the
+# same place via LEA_API_BASE_URL in the root .env, e.g.
+#   LEA_ADAPTER_PORT=8011 ./start-dev.sh   with LEA_API_BASE_URL=http://127.0.0.1:8011
+#
 # By default previous session data is KEPT (PLAN-system-hardening 0.3 — wiping
 # proofs and history must be opt-in, not the default of the most-typed command).
 #
@@ -64,7 +69,7 @@ cleanup() {
 }
 trap cleanup INT TERM
 
-echo "[start] Starting UI (adapter :8001 + frontend :5173)..."
+echo "[start] Starting UI (adapter :${LEA_ADAPTER_PORT:-8001} + frontend :5173)..."
 npm run dev:ui &
 pids+=($!)
 


### PR DESCRIPTION
Fixes #3.

The adapter's listen port was hardcoded as `8001` in four independent places, so a machine already using `:8001` for something else could not run the dev stack at all — `npm run dev` failed the preflight with no way out short of editing sources.

This threads all four through one `LEA_ADAPTER_PORT` variable, **defaulting to `8001` so nothing changes for anyone not setting it**:

| File | Change |
|---|---|
| `adapter/run_api.py` | uvicorn binds `PORT`, read from the env |
| `scripts/dev.mjs` | preflight + `/api/health` wait use `ADAPTER_PORT` |
| `vite.config.ts` | `/api` proxy target follows it |
| `scripts/doctor.mjs` | probe and its `[INFO]` line follow it |
| `package.json` | `dev:api:venv` uses `${LEA_ADAPTER_PORT:-8001}` |
| `start-dev.sh` | banner reports the real port; header documents the variable |

`dev.mjs` already spawns both children with `env: process.env`, so the Vite config picks the variable up for free.

The preflight failure now names the escape hatch, since that message is exactly where you find out the port is taken:

```
[dev] UI adapter API port 8001 is already in use. Stop the existing process (or set LEA_ADAPTER_PORT to a free port) and run npm run dev again.
```

## Out of scope

Docker is untouched — `run-lea.sh` already exposes `LEA_PORT` for the host-side mapping, and the container-internal port has no reason to move. The Overleaf companion is untouched too: it locates the adapter via `LEA_API_BASE_URL`, which was already configurable. The `README`/docs references to `:8001` stay accurate, since that is still the default.

## Verification

- Adapter started with `LEA_ADAPTER_PORT=8011`: binds `127.0.0.1:8011` (confirmed via `lsof`), `/api/health` returns `200`.
- Unset and empty values both fall back to `8001`, in both the Node and Python readers.
- `tsc --noEmit` clean; `node --check` clean on both scripts.
- `${LEA_ADAPTER_PORT:-8001}` expansion confirmed under `sh`, which is what `npm run` uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)